### PR TITLE
Allows Smart Agent Enroll Job to have specific job and pod annotations

### DIFF
--- a/charts/sedai-smart-agent/templates/sedai-smart-agent-enroll/sedai-smart-agentEnroll-job.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-smart-agent-enroll/sedai-smart-agentEnroll-job.yaml
@@ -23,12 +23,12 @@ spec:
         {{- with .Values.globalLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.globalAnnotations .Values.smartAgentEnroll.jobAnnotations }}
+      {{- if or .Values.globalAnnotations .Values.smartAgentEnroll.podAnnotations }}
       annotations:
         {{- with .Values.globalAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- range $key, $value := .Values.smartAgentEnroll.jobAnnotations }}
+        {{- range $key, $value := .Values.smartAgentEnroll.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/charts/sedai-smart-agent/templates/sedai-smart-agent-enroll/sedai-smart-agentEnroll-job.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-smart-agent-enroll/sedai-smart-agentEnroll-job.yaml
@@ -5,6 +5,15 @@ kind: Job
 metadata:
   name: "{{ .Values.workload.smartAgentEnroll.name }}"
   namespace: {{ .Values.namespace }}
+  {{- if or .Values.globalAnnotations .Values.smartAgentEnroll.jobAnnotations }}
+  annotations:
+    {{- with .Values.globalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- range $key, $value := .Values.smartAgentEnroll.jobAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   backoffLimit: 1
   template:
@@ -14,9 +23,14 @@ spec:
         {{- with .Values.globalLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.globalAnnotations }}
+      {{- if or .Values.globalAnnotations .Values.smartAgentEnroll.jobAnnotations }}
       annotations:
+        {{- with .Values.globalAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- range $key, $value := .Values.smartAgentEnroll.jobAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
     spec:
       serviceAccountName: "{{ .Values.workload.smartAgentEnroll.name }}-sa"

--- a/charts/sedai-smart-agent/values.yaml
+++ b/charts/sedai-smart-agent/values.yaml
@@ -26,6 +26,8 @@ smartAgentEnroll:
   enabled: true                     # Enables the Smart Agent enrollment job (one-time job per cluster)
   nodeSelector: {}                  # Node selector for Smart Agent enrollment job
   tolerations: []                   # Tolerations for Smart Agent enrollment job
+  jobAnnotations: {}                # Annotations for Smart Agent enrollment job
+  podAnnotations: {}                # Annotations for Smart Agent enrollment job
 
 sedaiPrometheus:
   enabled: false                    # Enables Sedai-managed Prometheus for metric collection


### PR DESCRIPTION
# Custom Annotations for Smart Agent Enroll Job

### Problem Statement

For service mesh enabled clusters, kubernetes jobs will be stuck in NotReady if the istio injection is enabled. This will cause deployment failures in GitOps say ArgoCD where the ApplicationSet rollout fails to install Sedai Smart Agent across a fleet of clusters

```
NAME                                 READY   STATUS     RESTARTS   AGE
sedai-smart-agent-enroll-job-5gkgp   1/2     NotReady   0          35m
```

```
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Pulled     36m   kubelet            Container image "docker.io/istio/proxyv2:1.20.6" already present on machine
  Normal  Created    36m   kubelet            Created container: istio-init
  Normal  Started    36m   kubelet            Started container istio-init
  Normal  Pulling    36m   kubelet            Pulling image "public.ecr.aws/sedai_io/sedai-smart-agent-enroll:v3.1.0"
  Normal  Pulled     36m   kubelet            Successfully pulled image "public.ecr.aws/sedai_io/sedai-smart-agent-enroll:v3.1.0" in 359ms (359ms including waiting). Image size: 144800275 bytes.
  Normal  Created    36m   kubelet            Created container: sedai-enroll
  Normal  Started    36m   kubelet            Started container sedai-enroll
  Normal  Pulled     36m   kubelet            Container image "docker.io/istio/proxyv2:1.20.6" already present on machine
  Normal  Created    36m   kubelet            Created container: istio-proxy
  Normal  Started    36m   kubelet            Started container istio-proxy
```

### Solution

Introduce jobAnnotations & podAnnotations to be supplied for smart agent enroll job

#### Sample Values for smart Agent Enroll

```
smartAgentEnroll:
  jobAnnotations:
    sidecar.istio.io/inject: "false"
  podAnnotations:
    sidecar.istio.io/inject: "false"
```

#### Validation

> helm template . -f disable-istio-injection-in-jobs.yaml

### Results

```
---
# Source: sedai-smart-agent/templates/sedai-smart-agent-enroll/sedai-smart-agentEnroll-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: "sedai-smart-agent-enroll-job"
  namespace: sedai-smart-agent
  annotations:
    sidecar.istio.io/inject: "false" <<<<<< Custom Job Annotations
spec:
  backoffLimit: 1
  template:
    metadata:
      labels:
        app: sedai-smart-agent-enroll-job
      annotations:
        sidecar.istio.io/inject: "false"  <<<<<< Custom Pod Annotations
    spec:
      serviceAccountName: "sedai-smart-agent-enroll-job-sa"
      restartPolicy: Never
      securityContext:
        runAsNonRoot: true
        runAsUser: 1001
        runAsGroup: 1001
        fsGroup: 1001

      containers:
        - name: sedai-enroll
          image: "public.ecr.aws/sedai_io/sedai-smart-agent-enroll:v3.1.0"
          command: ["/bin/sh", "-c", "python enroll_sedai.py"]
          imagePullPolicy: "Always"
          env:
            - name: POD_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace                  
          envFrom:
            - secretRef:
                name: "sedai-smart-agent-enroll-job-secret"
          securityContext:
            runAsNonRoot: true
            runAsUser: 1001
            runAsGroup: 1001
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
            seccompProfile:
              type: RuntimeDefault
```