### PR TITLE
feat(SED-21442): shared Postgres store for the spec controller (sedaiSync)

### DIFF
--- a/charts/sedai-smart-agent/Chart.yaml
+++ b/charts/sedai-smart-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sedai-smart-agent
 description: Helm Chart for deploying Sedai Smart Agent
 type: application
-version: 1.4.66
+version: 1.4.67
 appVersion: "1.4.66"

--- a/charts/sedai-smart-agent/templates/_helpers.tpl
+++ b/charts/sedai-smart-agent/templates/_helpers.tpl
@@ -81,3 +81,38 @@ Usage: {{ include "sedai-smart-agent.imageRepository" (dict "globalRegistry" .Va
 {{- .repository -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolves the spec-controller store driver, honouring the "pgx for new installs, existing
+customers flip manually" policy:
+  1. If sedaiSync.dbDriver is set explicitly, it always wins (the manual flip; also the escape hatch).
+  2. Else, if the controller Deployment already exists, PRESERVE its current driver — so an existing
+     SQLite customer is never auto-migrated on a `helm upgrade`; they stay put until they set
+     dbDriver=pgx themselves.
+  3. Else (brand-new install, no existing Deployment) default to "pgx" — greenfield goes straight to
+     the shared Postgres.
+Note: `lookup` returns empty during `helm template`/`--dry-run`, so previews render "pgx"; the
+real install/upgrade path resolves correctly.
+*/}}
+{{- define "sedai-smart-agent.specControllerDriver" -}}
+{{- if .Values.sedaiSync.dbDriver -}}
+{{- .Values.sedaiSync.dbDriver -}}
+{{- else -}}
+{{- $dep := lookup "apps/v1" "Deployment" .Release.Namespace "sedai-kube-spec-controller" -}}
+{{- if $dep -}}
+{{- $driver := "sqlite3" -}}
+{{- range $c := $dep.spec.template.spec.containers -}}
+{{- if eq $c.name "sedai-kube-spec-controller" -}}
+{{- range $e := $c.env -}}
+{{- if eq $e.name "SEDAI_KUBE_SPEC_CONTROLLER_DB_DRIVER_NAME" -}}
+{{- $driver = $e.value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $driver -}}
+{{- else -}}
+pgx
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sedai-smart-agent/templates/_helpers.tpl
+++ b/charts/sedai-smart-agent/templates/_helpers.tpl
@@ -81,38 +81,3 @@ Usage: {{ include "sedai-smart-agent.imageRepository" (dict "globalRegistry" .Va
 {{- .repository -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Resolves the spec-controller store driver, honouring the "pgx for new installs, existing
-customers flip manually" policy:
-  1. If sedaiSync.dbDriver is set explicitly, it always wins (the manual flip; also the escape hatch).
-  2. Else, if the controller Deployment already exists, PRESERVE its current driver — so an existing
-     SQLite customer is never auto-migrated on a `helm upgrade`; they stay put until they set
-     dbDriver=pgx themselves.
-  3. Else (brand-new install, no existing Deployment) default to "pgx" — greenfield goes straight to
-     the shared Postgres.
-Note: `lookup` returns empty during `helm template`/`--dry-run`, so previews render "pgx"; the
-real install/upgrade path resolves correctly.
-*/}}
-{{- define "sedai-smart-agent.specControllerDriver" -}}
-{{- if .Values.sedaiSync.dbDriver -}}
-{{- .Values.sedaiSync.dbDriver -}}
-{{- else -}}
-{{- $dep := lookup "apps/v1" "Deployment" .Release.Namespace "sedai-kube-spec-controller" -}}
-{{- if $dep -}}
-{{- $driver := "sqlite3" -}}
-{{- range $c := $dep.spec.template.spec.containers -}}
-{{- if eq $c.name "sedai-kube-spec-controller" -}}
-{{- range $e := $c.env -}}
-{{- if eq $e.name "SEDAI_KUBE_SPEC_CONTROLLER_DB_DRIVER_NAME" -}}
-{{- $driver = $e.value -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- $driver -}}
-{{- else -}}
-pgx
-{{- end -}}
-{{- end -}}
-{{- end -}}

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-secret.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-secret.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.sedaiSync.enabled .Values.sedaiSync.db.enabled }}
+{{- if not .Values.sedaiSync.db.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "sedai-kube-spec-controller-db"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sedai-smart-agent.labels" . | nindent 4 }}
+    app: "sedai-kube-spec-controller-db"
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.globalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  POSTGRES_USER: "{{ .Values.sedaiSync.db.user }}"
+  POSTGRES_PASSWORD: "{{ .Values.sedaiSync.db.password }}"
+  POSTGRES_DB: "{{ .Values.sedaiSync.db.name }}"
+{{- end }}
+{{- end }}

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-secret.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-secret.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "sedai-kube-spec-controller-db"
+  name: "sedai-kube-spec-store"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sedai-smart-agent.labels" . | nindent 4 }}
-    app: "sedai-kube-spec-controller-db"
+    app: "sedai-kube-spec-store"
     {{- with .Values.globalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-service.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-service.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.sedaiSync.enabled .Values.sedaiSync.db.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "sedai-kube-spec-controller-db"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sedai-smart-agent.labels" . | nindent 4 }}
+    app: "sedai-kube-spec-controller-db"
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.globalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+  - name: "postgres"
+    port: {{ .Values.sedaiSync.db.port }}
+    targetPort: 5432
+    protocol: TCP
+  selector:
+    app: "sedai-kube-spec-controller-db"
+  type: ClusterIP
+{{- end }}

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-service.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "sedai-kube-spec-controller-db"
+  name: "sedai-kube-spec-store"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sedai-smart-agent.labels" . | nindent 4 }}
-    app: "sedai-kube-spec-controller-db"
+    app: "sedai-kube-spec-store"
     {{- with .Values.globalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -21,6 +21,6 @@ spec:
     targetPort: 5432
     protocol: TCP
   selector:
-    app: "sedai-kube-spec-controller-db"
+    app: "sedai-kube-spec-store"
   type: ClusterIP
 {{- end }}

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-statefulset.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-statefulset.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: "sedai-kube-spec-controller-db"
+  name: "sedai-kube-spec-store"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sedai-smart-agent.labels" . | nindent 4 }}
-    app: "sedai-kube-spec-controller-db"
+    app: "sedai-kube-spec-store"
     {{- with .Values.globalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -15,15 +15,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  serviceName: "sedai-kube-spec-controller-db"
+  serviceName: "sedai-kube-spec-store"
   replicas: 1
   selector:
     matchLabels:
-      app: "sedai-kube-spec-controller-db"
+      app: "sedai-kube-spec-store"
   template:
     metadata:
       labels:
-        app: "sedai-kube-spec-controller-db"
+        app: "sedai-kube-spec-store"
         {{- with .Values.globalLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -65,7 +65,7 @@ spec:
           containerPort: 5432
         envFrom:
         - secretRef:
-            name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-controller-db" }}"
+            name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-store" }}"
         env:
         # Keep the data in a subdirectory so a lost+found on the volume root does not block init.
         - name: PGDATA

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-statefulset.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-db-statefulset.yaml
@@ -1,0 +1,108 @@
+{{- if and .Values.sedaiSync.enabled .Values.sedaiSync.db.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "sedai-kube-spec-controller-db"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sedai-smart-agent.labels" . | nindent 4 }}
+    app: "sedai-kube-spec-controller-db"
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.globalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: "sedai-kube-spec-controller-db"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "sedai-kube-spec-controller-db"
+  template:
+    metadata:
+      labels:
+        app: "sedai-kube-spec-controller-db"
+        {{- with .Values.globalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.globalAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.sedaiSync.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.globalTolerations .Values.sedaiSync.tolerations }}
+      tolerations:
+        {{- with .Values.globalTolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.sedaiSync.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.sedaiSync.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: postgres
+        image: "{{ include "sedai-smart-agent.imageRepository" (dict "globalRegistry" .Values.globalRegistry "repository" .Values.image.sedaiSyncDb.repository) }}:{{ .Values.image.sedaiSyncDb.imageTag }}"
+        imagePullPolicy: {{ .Values.image.sedaiSyncDb.imagePullPolicy }}
+        resources:
+          requests:
+            cpu: "{{ .Values.resources.sedaiSyncDb.cpu.requests }}"
+            memory: "{{ .Values.resources.sedaiSyncDb.memory.requests }}"
+          limits:
+            cpu: "{{ .Values.resources.sedaiSyncDb.cpu.limits }}"
+            memory: "{{ .Values.resources.sedaiSyncDb.memory.limits }}"
+        ports:
+        - name: postgres
+          containerPort: 5432
+        envFrom:
+        - secretRef:
+            name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-controller-db" }}"
+        env:
+        # Keep the data in a subdirectory so a lost+found on the volume root does not block init.
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/pgdata"
+        volumeMounts:
+        - name: data
+          mountPath: "/var/lib/postgresql/data"
+        readinessProbe:
+          exec:
+            command: ["pg_isready", "-U", "{{ .Values.sedaiSync.db.user }}", "-d", "{{ .Values.sedaiSync.db.name }}"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+        livenessProbe:
+          exec:
+            command: ["pg_isready", "-U", "{{ .Values.sedaiSync.db.user }}"]
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 3
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      {{- with .Values.sedaiSync.db.storageClassName }}
+      storageClassName: {{ . }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.sedaiSync.db.storage | default "2Gi" }}
+{{- end }}

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-deployment.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-deployment.yaml
@@ -101,7 +101,7 @@ spec:
         - name: SEDAI_KUBE_SPEC_CONTROLLER_SQLITE_DB_PATH
           value: "{{ .Values.sedaiSync.sqlitePath }}/sqlite.db"
         - name: SEDAI_KUBE_SPEC_CONTROLLER_DB_DRIVER_NAME
-          value: "{{ include "sedai-smart-agent.specControllerDriver" . }}"
+          value: "{{ .Values.sedaiSync.dbDriver | default "pgx" }}"
         {{- if .Values.sedaiSync.db.enabled }}
         # Shared Postgres store wiring. Present whenever the DB is deployed so the controller can be
         # switched to it by flipping sedaiSync.dbDriver to "pgx" — no other change needed.

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-deployment.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-deployment.yaml
@@ -101,7 +101,7 @@ spec:
         - name: SEDAI_KUBE_SPEC_CONTROLLER_SQLITE_DB_PATH
           value: "{{ .Values.sedaiSync.sqlitePath }}/sqlite.db"
         - name: SEDAI_KUBE_SPEC_CONTROLLER_DB_DRIVER_NAME
-          value: "{{ .Values.sedaiSync.dbDriver | default "sqlite3" }}"
+          value: "{{ include "sedai-smart-agent.specControllerDriver" . }}"
         {{- if .Values.sedaiSync.db.enabled }}
         # Shared Postgres store wiring. Present whenever the DB is deployed so the controller can be
         # switched to it by flipping sedaiSync.dbDriver to "pgx" — no other change needed.

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-deployment.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-deployment.yaml
@@ -106,23 +106,23 @@ spec:
         # Shared Postgres store wiring. Present whenever the DB is deployed so the controller can be
         # switched to it by flipping sedaiSync.dbDriver to "pgx" — no other change needed.
         - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_HOST
-          value: "sedai-kube-spec-controller-db"
+          value: "sedai-kube-spec-store"
         - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_PORT
           value: "{{ .Values.sedaiSync.db.port }}"
         - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_DB_NAME
           valueFrom:
             secretKeyRef:
-              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-controller-db" }}"
+              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-store" }}"
               key: "POSTGRES_DB"
         - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_USER
           valueFrom:
             secretKeyRef:
-              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-controller-db" }}"
+              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-store" }}"
               key: "POSTGRES_USER"
         - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-controller-db" }}"
+              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-store" }}"
               key: "POSTGRES_PASSWORD"
         - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_MAX_OPEN_CONNS
           value: "{{ .Values.sedaiSync.db.maxOpenConns }}"

--- a/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-deployment.yaml
+++ b/charts/sedai-smart-agent/templates/sedai-sync/sedai-sync-deployment.yaml
@@ -101,7 +101,36 @@ spec:
         - name: SEDAI_KUBE_SPEC_CONTROLLER_SQLITE_DB_PATH
           value: "{{ .Values.sedaiSync.sqlitePath }}/sqlite.db"
         - name: SEDAI_KUBE_SPEC_CONTROLLER_DB_DRIVER_NAME
-          value: "sqlite3"
+          value: "{{ .Values.sedaiSync.dbDriver | default "sqlite3" }}"
+        {{- if .Values.sedaiSync.db.enabled }}
+        # Shared Postgres store wiring. Present whenever the DB is deployed so the controller can be
+        # switched to it by flipping sedaiSync.dbDriver to "pgx" — no other change needed.
+        - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_HOST
+          value: "sedai-kube-spec-controller-db"
+        - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_PORT
+          value: "{{ .Values.sedaiSync.db.port }}"
+        - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-controller-db" }}"
+              key: "POSTGRES_DB"
+        - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-controller-db" }}"
+              key: "POSTGRES_USER"
+        - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.sedaiSync.db.existingSecret | default "sedai-kube-spec-controller-db" }}"
+              key: "POSTGRES_PASSWORD"
+        - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_MAX_OPEN_CONNS
+          value: "{{ .Values.sedaiSync.db.maxOpenConns }}"
+        - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_MAX_IDLE_CONNS
+          value: "{{ .Values.sedaiSync.db.maxIdleConns }}"
+        - name: SEDAI_KUBE_SPEC_CONTROLLER_PGSQL_CONN_MAX_LIFETIME_MINS
+          value: "{{ .Values.sedaiSync.db.connMaxLifetimeMins }}"
+        {{- end }}
         - name: ENCODE_LOGS_AS_JSON
           value: "{{ .Values.sedaiSync.encodeLogsAsJson }}"
         - name: CONTAINER_NAME

--- a/charts/sedai-smart-agent/values.yaml
+++ b/charts/sedai-smart-agent/values.yaml
@@ -75,6 +75,28 @@ sedaiSync:
   tolerations: []                   # Tolerations for both Sedai Sync and DB deployments
   priorityClassName: ""             # Priority class name for Sedai Sync deployment
   encodeLogsAsJson: "true"        # Whether to encode logs as JSON (true/false)
+  # Store driver for the spec controller. "sqlite3" (default) keeps the per-pod SQLite on PVC.
+  # Set to "pgx" to serve from the shared Postgres below (db.enabled must be true). Switching an
+  # existing install to "pgx" is the migration flip — see docs; the empty store is repopulated by
+  # the agent's WISB refresh. Only "sqlite3" and "pgx" are supported.
+  dbDriver: "sqlite3"
+  # Shared in-cluster Postgres store for the spec controller. Deployed alongside sedaiSync by
+  # default; when dbDriver stays "sqlite3" it is provisioned-but-idle (PGSQL_* env is wired so the
+  # only step to migrate is flipping dbDriver to "pgx"). Set db.enabled=false to opt out entirely.
+  db:
+    enabled: true                   # Deploy the shared Postgres store for the spec controller
+    name: "sedai_kube_spec_controller_db"   # Postgres database name
+    port: 5432                      # Postgres service/container port
+    user: "postgres"                # Postgres username (used when existingSecret is empty)
+    password: "postgres"            # Postgres password — OVERRIDE in production installs
+    existingSecret: ""              # Name of a pre-created Secret with keys POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB; if set, user/password/name above are ignored
+    storage: "2Gi"                  # PVC size for the Postgres data volume (ReadWriteOnce)
+    storageClassName: ""            # StorageClass for the Postgres PVC ("" = cluster default)
+    # Client connection-pool caps applied by each controller replica (must satisfy
+    # replicas * maxOpenConns <= Postgres max_connections - headroom).
+    maxOpenConns: 20
+    maxIdleConns: 5
+    connMaxLifetimeMins: 30
 
 sedaiNodeExporter:
   enabled: false
@@ -188,6 +210,11 @@ image:
     imageTag: 0.1.4
     imagePullPolicy: IfNotPresent
 
+  sedaiSyncDb:
+    repository: sedai_io/postgres
+    imageTag: 16-alpine
+    imagePullPolicy: IfNotPresent
+
   busyBox:
     repository: sedai_io/busybox
     imageTag: 1.37.0
@@ -262,7 +289,15 @@ resources:
       requests: "1024Mi"
       limits: "1024Mi"
     storage: "2Gi"                      # Persistent volume storage for SQLite database
-  
+
+  sedaiSyncDb:
+    cpu:
+      requests: "100m"
+      limits: "1"
+    memory:
+      requests: "256Mi"
+      limits: "512Mi"
+
   sedaiBeyla:
     cpu:
       requests: "500m"

--- a/charts/sedai-smart-agent/values.yaml
+++ b/charts/sedai-smart-agent/values.yaml
@@ -75,14 +75,13 @@ sedaiSync:
   tolerations: []                   # Tolerations for both Sedai Sync and DB deployments
   priorityClassName: ""             # Priority class name for Sedai Sync deployment
   encodeLogsAsJson: "true"        # Whether to encode logs as JSON (true/false)
-  # Store driver for the spec controller. Leave EMPTY for the default policy:
-  #   * brand-new install  -> "pgx"     (greenfield goes straight to the shared Postgres below)
-  #   * existing install   -> preserved (an existing SQLite customer is never auto-migrated on a
-  #                                       helm upgrade — they stay on sqlite3 until they flip)
-  # Set explicitly to force a value: "pgx" is the manual migration flip for an existing customer
-  # (the empty store repopulates via the agent's WISB refresh); "sqlite3" pins/rolls back to SQLite.
-  # Only "sqlite3" and "pgx" are supported. db.enabled must be true to use "pgx".
-  dbDriver: ""
+  # Store driver for the spec controller. Defaults to "pgx" (the shared Postgres below) going
+  # forward, so new installs use Postgres. Only "sqlite3" and "pgx" are supported; db.enabled must
+  # be true for "pgx".
+  # EXISTING SQLite customers: set this to "sqlite3" in their per-account values before upgrading so
+  # they are NOT auto-migrated, then flip to "pgx" manually when ready (the empty store repopulates
+  # via the agent's WISB refresh). This is set the same way sedaiSync.enabled is — per account.
+  dbDriver: "pgx"
   # Shared in-cluster Postgres store for the spec controller. Deployed alongside sedaiSync by
   # default; when dbDriver stays "sqlite3" it is provisioned-but-idle (PGSQL_* env is wired so the
   # only step to migrate is flipping dbDriver to "pgx"). Set db.enabled=false to opt out entirely.

--- a/charts/sedai-smart-agent/values.yaml
+++ b/charts/sedai-smart-agent/values.yaml
@@ -75,11 +75,14 @@ sedaiSync:
   tolerations: []                   # Tolerations for both Sedai Sync and DB deployments
   priorityClassName: ""             # Priority class name for Sedai Sync deployment
   encodeLogsAsJson: "true"        # Whether to encode logs as JSON (true/false)
-  # Store driver for the spec controller. "sqlite3" (default) keeps the per-pod SQLite on PVC.
-  # Set to "pgx" to serve from the shared Postgres below (db.enabled must be true). Switching an
-  # existing install to "pgx" is the migration flip — see docs; the empty store is repopulated by
-  # the agent's WISB refresh. Only "sqlite3" and "pgx" are supported.
-  dbDriver: "sqlite3"
+  # Store driver for the spec controller. Leave EMPTY for the default policy:
+  #   * brand-new install  -> "pgx"     (greenfield goes straight to the shared Postgres below)
+  #   * existing install   -> preserved (an existing SQLite customer is never auto-migrated on a
+  #                                       helm upgrade — they stay on sqlite3 until they flip)
+  # Set explicitly to force a value: "pgx" is the manual migration flip for an existing customer
+  # (the empty store repopulates via the agent's WISB refresh); "sqlite3" pins/rolls back to SQLite.
+  # Only "sqlite3" and "pgx" are supported. db.enabled must be true to use "pgx".
+  dbDriver: ""
   # Shared in-cluster Postgres store for the spec controller. Deployed alongside sedaiSync by
   # default; when dbDriver stays "sqlite3" it is provisioned-but-idle (PGSQL_* env is wired so the
   # only step to migrate is flipping dbDriver to "pgx"). Set db.enabled=false to opt out entirely.


### PR DESCRIPTION
## What

Adds an in-cluster **shared Postgres store** (`sedai-kube-spec-store`) for the spec controller (`sedaiSync`) to the `sedai-smart-agent` chart — the deployment side of SED-21442 (moving the controller off per-pod SQLite onto a shared Postgres for HA/multi-replica).

## Behaviour

- **Deployed by default with the controller** — gated on `sedaiSync.enabled && sedaiSync.db.enabled`; `db.enabled` defaults **true**. Opt out with `db.enabled=false`. (Nothing renders when `sedaiSync.enabled=false`, unchanged — the controller itself remains opt-in per account, same as today.)
- **Store driver defaults to `pgx` going forward** — new installs use the shared Postgres. `sedaiSync.dbDriver` is a plain value (default `pgx`), set per-account the same way `sedaiSync.enabled` is; no chart-side install/upgrade detection.
- **Existing SQLite customers migrate manually** — set `sedaiSync.dbDriver: sqlite3` in their per-account values **before** upgrading so they are not auto-migrated, then flip to `pgx` when ready (the empty store repopulates via the agent's WISB refresh).

## Changes

- **New** `templates/sedai-sync/`: `sedai-sync-db-statefulset.yaml` (`postgres:16-alpine`, PVC-backed `volumeClaimTemplate` RWO/2Gi/optional storageClass, `pg_isready` probes, `PGDATA` subdir), `sedai-sync-db-service.yaml` (ClusterIP :5432), `sedai-sync-db-secret.yaml` (creds; skipped when `existingSecret` is set).
- **Edit** `sedai-sync-deployment.yaml`: driver = `{{ .Values.sedaiSync.dbDriver | default "pgx" }}`; `PGSQL_*` env block (host/port/db/user/password from the Secret + pool caps) added when the DB is enabled.
- **values.yaml**: `sedaiSync.db.*` (enabled, name, port, user/password, existingSecret, storage, storageClassName, pool caps) + `sedaiSync.dbDriver`; `image.sedaiSyncDb` (postgres:16-alpine); `resources.sedaiSyncDb`.
- **Chart.yaml**: 1.4.66 → 1.4.67.

## Validation

`helm template` (containerized helm 3.16.2): DB StatefulSet/Service/Secret render as `sedai-kube-spec-store`; controller gets `PGSQL_*` env; driver = `pgx` by default and `sqlite3` when overridden; `db.enabled=false` → zero DB objects.

## Notes for review (DevOps)

1. **Existing-customer safety**: because the default is now `pgx`, existing SQLite customers must be pinned to `sqlite3` in their per-account values (or migrated) before their chart version is bumped — otherwise they auto-flip on upgrade. This is the deliberate trade for keeping it simple (no `lookup`/install-detection in the chart); handled via the same per-account values mechanism that sets `sedaiSync.enabled`.
2. **Controller image**: chart pins `image.sedaiSync.imageTag: 0.1.4` (pre-pgsql-fix). The `pgx` path needs a controller image containing sedai-kube-spec-controller PR #105 (dialect fixes). **Bump the controller image to a #105-containing release before shipping this**, since new installs now default to `pgx`.
3. **Default password** is a placeholder — override in prod values or set `sedaiSync.db.existingSecret`. Can switch to a Helm-generated random if preferred.
4. **Version** bumped `version`→1.4.67 (left `appVersion`) — adjust to your convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)